### PR TITLE
Add setting to ignore collisions

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -201,7 +201,10 @@ local function move_entity(event)
             force = entity_force
         }
 
-        if not player.mod_settings['dolly-ignore-collisions'].value and not (player.can_place_entity(params) and not entity.surface.find_entity('entity-ghost', target_pos)) then
+        if not (settings.global['dolly-allow-ignore-collisions'].value and player.mod_settings['dolly-ignore-collisions'].value)
+            and not (player.can_place_entity(params)
+            and not entity.surface.find_entity('entity-ghost', target_pos))
+            then
             return teleport_and_update(start_pos, false, {'picker-dollies.no-room', entity.localised_name})
         end
 

--- a/control.lua
+++ b/control.lua
@@ -201,7 +201,7 @@ local function move_entity(event)
             force = entity_force
         }
 
-        if not (player.can_place_entity(params) and not entity.surface.find_entity('entity-ghost', target_pos)) then
+        if not player.mod_settings['dolly-ignore-collisions'].value and not (player.can_place_entity(params) and not entity.surface.find_entity('entity-ghost', target_pos)) then
             return teleport_and_update(start_pos, false, {'picker-dollies.no-room', entity.localised_name})
         end
 

--- a/locale/en/dollies_en.cfg
+++ b/locale/en/dollies_en.cfg
@@ -9,9 +9,11 @@ dolly-rotate-saved-reverse=Reverse rotate saved dolly
 
 [mod-setting-name]
 dolly-save-entity=Save last moved entity
+dolly-ignore-collisions=Ignore collision boxes
 
 [mod-setting-description]
 dolly-save-entity=Temporarily Saves entities so they can be moved without having to keep selecing them.
+dolly-ignore-collisions=Allow moving entities such that they collide/overlap. Dangerous and cheat-y.
 
 [picker-dollies]
 cant-be-teleported=__1__ does not support moving.

--- a/locale/en/dollies_en.cfg
+++ b/locale/en/dollies_en.cfg
@@ -10,10 +10,12 @@ dolly-rotate-saved-reverse=Reverse rotate saved dolly
 [mod-setting-name]
 dolly-save-entity=Save last moved entity
 dolly-ignore-collisions=Ignore collision boxes
+dolly-allow-ignore-collisions=Allow ignoring collisions
 
 [mod-setting-description]
 dolly-save-entity=Temporarily Saves entities so they can be moved without having to keep selecing them.
-dolly-ignore-collisions=Allow moving entities such that they collide/overlap. Dangerous and cheat-y.
+dolly-ignore-collisions=Allow moving entities such that they collide/overlap. Forbidden by default by global setting. Dangerous and cheat-y.
+dolly-allow-ignore-collisions=Allow players to use the "Ignore collision boxes" setting.
 
 [picker-dollies]
 cant-be-teleported=__1__ does not support moving.

--- a/settings.lua
+++ b/settings.lua
@@ -10,5 +10,11 @@ data:extend {
         setting_type = 'runtime-per-user',
         type = 'bool-setting',
         default_value = false
+    },
+    {
+        name = 'dolly-allow-ignore-collisions',
+        setting_type = 'runtime-global',
+        type = 'bool-setting',
+        default_value = false
     }
 }

--- a/settings.lua
+++ b/settings.lua
@@ -4,5 +4,11 @@ data:extend {
         setting_type = 'runtime-per-user',
         type = 'bool-setting',
         default_value = true
+    },
+    {
+        name = 'dolly-ignore-collisions',
+        setting_type = 'runtime-per-user',
+        type = 'bool-setting',
+        default_value = false
     }
 }


### PR DESCRIPTION
This per-user setting disables the check for entities colliding when moving. It is cheaty and dangerous if you leave entities overlapping, but very helpful when trying to rearrange already-packed-together entities. I found myself needing this to swap the position of two train stations with complex circuit connections that I didn't want to re-connect by hand.